### PR TITLE
Script Loader for vanilla js workloads

### DIFF
--- a/apps/todomvc/todomvc-web-components/dist/index.html
+++ b/apps/todomvc/todomvc-web-components/dist/index.html
@@ -27,7 +27,7 @@
             <p class="footer-text">Press 'enter' to add the todo.</p>
             <p class="footer-text">Double-click to edit a todo</p>
         </footer>
-        <script type="module" src="benchmark-connector.min.js"></script>
+        <script type="module" src="index.js"></script>
         <script type="module" src="workload-test.js"></script>
     </body>
 </html>

--- a/apps/todomvc/todomvc-web-components/dist/index.js
+++ b/apps/todomvc/todomvc-web-components/dist/index.js
@@ -8,4 +8,4 @@ function handleOnSuccess() {
     console.log("handleOnSuccess");
 }
 
-await loadScript({ id: "benchmark-connector", url: "benchmark-connector.min.js", type: "module", strategy: "lazyOnLoad", onSuccess: handleOnSuccess, onError: handleOnError });
+await loadScript({ url: "benchmark-connector.min.js", type: "module", strategy: "lazyOnLoad", onSuccess: handleOnSuccess, onError: handleOnError });

--- a/apps/todomvc/todomvc-web-components/dist/index.js
+++ b/apps/todomvc/todomvc-web-components/dist/index.js
@@ -1,3 +1,3 @@
 import { loadScript } from "./utils/script-loader.js";
 
-await loadScript({ url: "benchmark-connector.min.js", type: "module", strategy: "lazyOnLoad" });
+await loadScript({ id: "benchmark-connector", url: "benchmark-connector.min.js", type: "module", strategy: "lazyOnLoad" });

--- a/apps/todomvc/todomvc-web-components/dist/index.js
+++ b/apps/todomvc/todomvc-web-components/dist/index.js
@@ -1,0 +1,3 @@
+import { loadScript } from "./utils/script-loader.js";
+
+await loadScript({ url: "benchmark-connector.min.js", type: "module", strategy: "lazyOnLoad" });

--- a/apps/todomvc/todomvc-web-components/dist/index.js
+++ b/apps/todomvc/todomvc-web-components/dist/index.js
@@ -8,4 +8,9 @@ function handleOnSuccess() {
     console.log("handleOnSuccess");
 }
 
-await loadScript({ url: "benchmark-connector.min.js", type: "module", strategy: "lazyOnLoad", onSuccess: handleOnSuccess, onError: handleOnError });
+try {
+    await loadScript({ url: "benchmark-connector.min.js", type: "module", strategy: "lazyOnLoad" });
+    handleOnSuccess();
+}catch(e) {
+    handleOnError(e);
+}

--- a/apps/todomvc/todomvc-web-components/dist/index.js
+++ b/apps/todomvc/todomvc-web-components/dist/index.js
@@ -1,3 +1,11 @@
 import { loadScript } from "./utils/script-loader.js";
 
-await loadScript({ id: "benchmark-connector", url: "benchmark-connector.min.js", type: "module", strategy: "lazyOnLoad" });
+function handleOnError(e) {
+    console.log("handleOnError", e);
+}
+
+function handleOnSuccess() {
+    console.log("handleOnSuccess");
+}
+
+await loadScript({ id: "benchmark-connector", url: "benchmark-connector.min.js", type: "module", strategy: "lazyOnLoad", onSuccess: handleOnSuccess, onError: handleOnError });

--- a/apps/todomvc/todomvc-web-components/dist/utils/request-idle-callback.js
+++ b/apps/todomvc/todomvc-web-components/dist/utils/request-idle-callback.js
@@ -5,7 +5,7 @@ export const requestIdleCallback = window.requestIdleCallback =
         const timeoutId = window.setTimeout(function () {
             cb({
                 didTimeout: false,
-                timeRemaining: function () {
+                timeRemaining() {
                     return Math.max(0, 50 - (Date.now() - start));
                 }
             });

--- a/apps/todomvc/todomvc-web-components/dist/utils/request-idle-callback.js
+++ b/apps/todomvc/todomvc-web-components/dist/utils/request-idle-callback.js
@@ -1,0 +1,21 @@
+export const requestIdleCallback = window.requestIdleCallback =
+    window.requestIdleCallback ||
+    function (cb) {
+        const start = Date.now();
+        const timeoutId = window.setTimeout(function () {
+            cb({
+                didTimeout: false,
+                timeRemaining: function () {
+                    return Math.max(0, 50 - (Date.now() - start));
+                }
+            });
+        }, 1)
+
+        return timeoutId;
+    }
+
+export const cancelIdleCallback = window.cancelIdleCallback =
+    window.cancelIdleCallback ||
+    function (id) {
+        window.clearTimeout(id);
+    }

--- a/apps/todomvc/todomvc-web-components/dist/utils/request-idle-callback.js
+++ b/apps/todomvc/todomvc-web-components/dist/utils/request-idle-callback.js
@@ -14,8 +14,4 @@ export const requestIdleCallback = window.requestIdleCallback =
         return timeoutId;
     }
 
-export const cancelIdleCallback = window.cancelIdleCallback =
-    window.cancelIdleCallback ||
-    function (id) {
-        window.clearTimeout(id);
-    }
+export const cancelIdleCallback = window.cancelIdleCallback || window.clearTimeout.bind(window);

--- a/apps/todomvc/todomvc-web-components/dist/utils/script-loader.js
+++ b/apps/todomvc/todomvc-web-components/dist/utils/script-loader.js
@@ -1,0 +1,37 @@
+import { requestIdleCallback } from "./request-idle-callback.js";
+
+function addScript(scriptEl, location) {
+    return new Promise((resolve) => {
+        if (location === 'head') {
+            document.head.appendChild(scriptEl);
+        } else {
+            document.body.appendChild(scriptEl);
+        }
+        return resolve({ success: true, type: "addScript"});
+    });
+}
+
+function initScript(scriptEl, url, strategy) {
+    return new Promise((resolve, reject) => {
+      scriptEl.onload = () => resolve({success: true, type: "loadScript"});
+      scriptEl.onerror = () => reject({success: false, type: "loadScript"});
+
+      switch(strategy) {
+        case "lazyOnLoad":
+            requestIdleCallback(() => scriptEl.setAttribute('src', url));
+            break;
+        default:
+            scriptEl.setAttribute('src', url);
+      }
+    });
+}
+
+export async function loadScript({ url, type, strategy, location, onError, onSuccess } = {}) {
+    const promisesToResolve = [];
+    const scriptEl = document.createElement('script');
+    scriptEl.type = type;
+    promisesToResolve.push(addScript(scriptEl, location));
+    promisesToResolve.push(initScript(scriptEl, url, strategy));
+
+    await Promise.all(promisesToResolve).then(() => onSuccess?.()).catch(() => onError?.());
+}

--- a/apps/todomvc/todomvc-web-components/dist/utils/script-loader.js
+++ b/apps/todomvc/todomvc-web-components/dist/utils/script-loader.js
@@ -41,7 +41,7 @@ function buildScript({scriptEl, code}) {
     });
 }
 
-export async function loadScript({ id, url = "", code = "", type = "", strategy = "default", location = "body", onError = () => {}, onSuccess = () => {} } = {}) {
+export async function loadScript({ id, url = "", code = "", type = "", strategy = "default", location = "body", onError, onSuccess } = {}) {
     // create a script element
     const { scriptEl } = await createScript({type});
 
@@ -50,10 +50,12 @@ export async function loadScript({ id, url = "", code = "", type = "", strategy 
 
     if (code !== "") {
         // add inline code to script element
-        await buildScript({scriptEl, code}).then(() => onSuccess?.()).catch(() => onError?.());
+        await buildScript({scriptEl, code});
+        onSuccess?.();
     } else {
         // load external url
-        await initScript({scriptEl, url, strategy}).then(() => onSuccess?.()).catch(() => onError?.());
+        const {success} = await initScript({scriptEl, url, strategy});
+        success ? onSuccess?.() : onError?.();
     }
 
     return ({ success: true, type: "loadScript", id});

--- a/apps/todomvc/todomvc-web-components/dist/utils/script-loader.js
+++ b/apps/todomvc/todomvc-web-components/dist/utils/script-loader.js
@@ -1,6 +1,6 @@
 import { requestIdleCallback } from "./request-idle-callback.js";
 
-function createScript(type) {
+function createScript({type}) {
     return new Promise((resolve) => {
         const scriptEl = document.createElement('script');
         if (type !== "") scriptEl.type = type;
@@ -8,7 +8,7 @@ function createScript(type) {
     });
 }
 
-function addScript(scriptEl, location) {
+function addScript({scriptEl, location}) {
     return new Promise((resolve) => {
         if (location === 'head') {
             document.head.appendChild(scriptEl);
@@ -19,7 +19,7 @@ function addScript(scriptEl, location) {
     });
 }
 
-function initScript(scriptEl, url, strategy) {
+function initScript({scriptEl, url, strategy}) {
     return new Promise((resolve, reject) => {
       scriptEl.onload = () => resolve({success: true, type: "initScript"});
       scriptEl.onerror = () => reject({success: false, type: "initScript"});
@@ -34,7 +34,7 @@ function initScript(scriptEl, url, strategy) {
     });
 }
 
-function buildScript(scriptEl, code) {
+function buildScript({scriptEl, code}) {
     return new Promise((resolve) => {
         scriptEl.textContent = code;
         return resolve({ success: true, type: "buildScript"});
@@ -43,17 +43,17 @@ function buildScript(scriptEl, code) {
 
 export async function loadScript({ id, url = "", code = "", type = "", strategy = "default", location = "body", onError = () => {}, onSuccess = () => {} } = {}) {
     // create a script element
-    const { scriptEl } = await createScript(type);
+    const { scriptEl } = await createScript({type});
 
     // add script to document
-    await addScript(scriptEl, location);
+    await addScript({scriptEl, location});
 
     if (code !== "") {
         // add inline code to script element
-        await buildScript(scriptEl, code).then(() => onSuccess?.()).catch(() => onError?.());
+        await buildScript({scriptEl, code}).then(() => onSuccess?.()).catch(() => onError?.());
     } else {
         // load external url
-        await initScript(scriptEl, url, strategy).then(() => onSuccess?.()).catch(() => onError?.());
+        await initScript({scriptEl, url, strategy}).then(() => onSuccess?.()).catch(() => onError?.());
     }
 
     return ({ success: true, type: "loadScript", id});

--- a/apps/todomvc/todomvc-web-components/dist/utils/script-loader.js
+++ b/apps/todomvc/todomvc-web-components/dist/utils/script-loader.js
@@ -39,8 +39,6 @@ export async function loadScript({
     type = "",
     strategy = "default",
     location = "body",
-    onSuccess,
-    onError,
 } = {}) {
     // create a script element
     const scriptEl = createScript({ type });
@@ -51,7 +49,6 @@ export async function loadScript({
     if (code !== "") {
         // add inline code to script element
         buildScript({ scriptEl, code });
-        onSuccess();
     } else {
         // load external url
         await initScript({ scriptEl, url, strategy });

--- a/apps/todomvc/todomvc-web-components/dist/utils/script-loader.js
+++ b/apps/todomvc/todomvc-web-components/dist/utils/script-loader.js
@@ -34,7 +34,6 @@ function initScript({ scriptEl, url, strategy }) {
 }
 
 export async function loadScript({
-    id,
     url = "",
     code = "",
     type = "",

--- a/apps/todomvc/todomvc-web-components/dist/utils/script-loader.js
+++ b/apps/todomvc/todomvc-web-components/dist/utils/script-loader.js
@@ -34,8 +34,25 @@ function initScript(scriptEl, url, strategy) {
     });
 }
 
-export async function loadScript({ url, type = "", strategy = "default", location, onError, onSuccess } = {}) {
-    const { scriptEl } = await createScript(type)
+function buildScript(scriptEl, code) {
+    return new Promise((resolve) => {
+        scriptEl.textContent = code;
+        return resolve({ success: true, type: "buildScript"});
+    });
+}
+
+export async function loadScript({ url, code = "", type = "", strategy = "default", location, onError, onSuccess } = {}) {
+    // create a script element
+    const { scriptEl } = await createScript(type);
+    
+    // add script to document
     await addScript(scriptEl, location);
-    await initScript(scriptEl, url, strategy).then(() => onSuccess?.()).catch(() => onError?.());
+
+    if (code !== "") {
+        // add inline code to script element
+        await buildScript(scriptEl, code).then(() => onSuccess?.()).catch(() => onError?.());
+    } else {
+        // load external url
+        await initScript(scriptEl, url, strategy).then(() => onSuccess?.()).catch(() => onError?.());
+    }
 }

--- a/apps/todomvc/todomvc-web-components/dist/utils/script-loader.js
+++ b/apps/todomvc/todomvc-web-components/dist/utils/script-loader.js
@@ -3,7 +3,7 @@ import { requestIdleCallback } from "./request-idle-callback.js";
 function createScript(type) {
     return new Promise((resolve) => {
         const scriptEl = document.createElement('script');
-        scriptEl.type = type;
+        if (type !== "") scriptEl.type = type;
         return resolve({ success: true, type: "createScript", scriptEl});
     });
 }
@@ -34,7 +34,7 @@ function initScript(scriptEl, url, strategy) {
     });
 }
 
-export async function loadScript({ url, type, strategy, location, onError, onSuccess } = {}) {
+export async function loadScript({ url, type = "", strategy = "default", location, onError, onSuccess } = {}) {
     const { scriptEl } = await createScript(type)
     await addScript(scriptEl, location);
     await initScript(scriptEl, url, strategy).then(() => onSuccess?.()).catch(() => onError?.());

--- a/apps/todomvc/todomvc-web-components/dist/utils/script-loader.js
+++ b/apps/todomvc/todomvc-web-components/dist/utils/script-loader.js
@@ -1,5 +1,13 @@
 import { requestIdleCallback } from "./request-idle-callback.js";
 
+function createScript(type) {
+    return new Promise((resolve) => {
+        const scriptEl = document.createElement('script');
+        scriptEl.type = type;
+        return resolve({ success: true, type: "createScript", scriptEl});
+    });
+}
+
 function addScript(scriptEl, location) {
     return new Promise((resolve) => {
         if (location === 'head') {
@@ -27,11 +35,7 @@ function initScript(scriptEl, url, strategy) {
 }
 
 export async function loadScript({ url, type, strategy, location, onError, onSuccess } = {}) {
-    const promisesToResolve = [];
-    const scriptEl = document.createElement('script');
-    scriptEl.type = type;
-    promisesToResolve.push(addScript(scriptEl, location));
-    promisesToResolve.push(initScript(scriptEl, url, strategy));
-
-    await Promise.all(promisesToResolve).then(() => onSuccess?.()).catch(() => onError?.());
+    const { scriptEl } = await createScript(type)
+    await addScript(scriptEl, location);
+    await initScript(scriptEl, url, strategy).then(() => onSuccess?.()).catch(() => onError?.());
 }

--- a/apps/todomvc/todomvc-web-components/dist/utils/script-loader.js
+++ b/apps/todomvc/todomvc-web-components/dist/utils/script-loader.js
@@ -54,11 +54,6 @@ export async function loadScript({
         onSuccess();
     } else {
         // load external url
-        try {
-            await initScript({ scriptEl, url, strategy });
-            onSuccess?.();
-        } catch (e) {
-            onError?.(e);
-        }
+        await initScript({ scriptEl, url, strategy });
     }
 }

--- a/apps/todomvc/todomvc-web-components/dist/utils/script-loader.js
+++ b/apps/todomvc/todomvc-web-components/dist/utils/script-loader.js
@@ -21,8 +21,8 @@ function addScript(scriptEl, location) {
 
 function initScript(scriptEl, url, strategy) {
     return new Promise((resolve, reject) => {
-      scriptEl.onload = () => resolve({success: true, type: "loadScript"});
-      scriptEl.onerror = () => reject({success: false, type: "loadScript"});
+      scriptEl.onload = () => resolve({success: true, type: "initScript"});
+      scriptEl.onerror = () => reject({success: false, type: "initScript"});
 
       switch(strategy) {
         case "lazyOnLoad":
@@ -41,10 +41,10 @@ function buildScript(scriptEl, code) {
     });
 }
 
-export async function loadScript({ url, code = "", type = "", strategy = "default", location, onError, onSuccess } = {}) {
+export async function loadScript({ id, url = "", code = "", type = "", strategy = "default", location = "body", onError = () => {}, onSuccess = () => {} } = {}) {
     // create a script element
     const { scriptEl } = await createScript(type);
-    
+
     // add script to document
     await addScript(scriptEl, location);
 
@@ -55,4 +55,6 @@ export async function loadScript({ url, code = "", type = "", strategy = "defaul
         // load external url
         await initScript(scriptEl, url, strategy).then(() => onSuccess?.()).catch(() => onError?.());
     }
+
+    return ({ success: true, type: "loadScript", id});
 }

--- a/apps/todomvc/todomvc-web-components/index.html
+++ b/apps/todomvc/todomvc-web-components/index.html
@@ -27,7 +27,7 @@
             <p class="footer-text">Press 'enter' to add the todo.</p>
             <p class="footer-text">Double-click to edit a todo</p>
         </footer>
-        <script type="module" src="benchmark-connector.min.js"></script>
+        <script type="module" src="index.js"></script>
         <script type="module" src="workload-test.js"></script>
     </body>
 </html>

--- a/apps/todomvc/todomvc-web-components/index.js
+++ b/apps/todomvc/todomvc-web-components/index.js
@@ -1,0 +1,3 @@
+import { loadScript } from "./src/utils/script-loader.js";
+
+await loadScript({ url: "benchmark-connector.min.js", type: "module", strategy: "lazyOnLoad" });

--- a/apps/todomvc/todomvc-web-components/index.js
+++ b/apps/todomvc/todomvc-web-components/index.js
@@ -8,4 +8,4 @@ function handleOnSuccess() {
     console.log("handleOnSuccess");
 }
 
-await loadScript({ id: "benchmark-connector", url: "benchmark-connector.min.js", type: "module", strategy: "lazyOnLoad", onSuccess: handleOnSuccess, onError: handleOnError });
+await loadScript({ url: "benchmark-connector.min.js", type: "module", strategy: "lazyOnLoad", onSuccess: handleOnSuccess, onError: handleOnError });

--- a/apps/todomvc/todomvc-web-components/index.js
+++ b/apps/todomvc/todomvc-web-components/index.js
@@ -8,4 +8,9 @@ function handleOnSuccess() {
     console.log("handleOnSuccess");
 }
 
-await loadScript({ url: "benchmark-connector.min.js", type: "module", strategy: "lazyOnLoad", onSuccess: handleOnSuccess, onError: handleOnError });
+try {
+    await loadScript({ url: "benchmark-connector.min.js", type: "module", strategy: "lazyOnLoad" });
+    handleOnSuccess();
+}catch(e) {
+    handleOnError(e);
+}

--- a/apps/todomvc/todomvc-web-components/index.js
+++ b/apps/todomvc/todomvc-web-components/index.js
@@ -1,3 +1,11 @@
 import { loadScript } from "./src/utils/script-loader.js";
 
-await loadScript({ id: "benchmark-connector", url: "benchmark-connector.min.js", type: "module", strategy: "lazyOnLoad" });
+function handleOnError(e) {
+    console.log("handleOnError", e);
+}
+
+function handleOnSuccess() {
+    console.log("handleOnSuccess");
+}
+
+await loadScript({ id: "benchmark-connector", url: "benchmark-connector.min.js", type: "module", strategy: "lazyOnLoad", onSuccess: handleOnSuccess, onError: handleOnError });

--- a/apps/todomvc/todomvc-web-components/index.js
+++ b/apps/todomvc/todomvc-web-components/index.js
@@ -1,3 +1,3 @@
 import { loadScript } from "./src/utils/script-loader.js";
 
-await loadScript({ url: "benchmark-connector.min.js", type: "module", strategy: "lazyOnLoad" });
+await loadScript({ id: "benchmark-connector", url: "benchmark-connector.min.js", type: "module", strategy: "lazyOnLoad" });

--- a/apps/todomvc/todomvc-web-components/scripts/build.js
+++ b/apps/todomvc/todomvc-web-components/scripts/build.js
@@ -3,6 +3,7 @@ const { createDirectory, copyDirectory, copyFiles, updateImports } = require("ap
 const filesToMove = [
     { src: "index.html", dest: "./dist/index.html" },
     { src: "favicon.ico", dest: "./dist/favicon.ico" },
+    { src: "index.js", dest: "./dist/index.js" },
     { src: "benchmark-connector.min.js", dest: "./dist/benchmark-connector.min.js" },
     { src: "workload-testing-utils.min.js", dest: "./dist/workload-testing-utils.min.js" },
     { src: "todomvc-testing-utils.min.js", dest: "./dist/todomvc-testing-utils.min.js" },
@@ -28,7 +29,7 @@ const importsToRename = [
     {
         src: "src/",
         dest: "",
-        files: [ "./dist/index.html" ]
+        files: [ "./dist/index.html", "./dist/index.js" ]
     },
     {
         src: "../../../node_modules/todomvc-css/dist/",

--- a/apps/todomvc/todomvc-web-components/src/utils/request-idle-callback.js
+++ b/apps/todomvc/todomvc-web-components/src/utils/request-idle-callback.js
@@ -5,7 +5,7 @@ export const requestIdleCallback = window.requestIdleCallback =
         const timeoutId = window.setTimeout(function () {
             cb({
                 didTimeout: false,
-                timeRemaining: function () {
+                timeRemaining() {
                     return Math.max(0, 50 - (Date.now() - start));
                 }
             });

--- a/apps/todomvc/todomvc-web-components/src/utils/request-idle-callback.js
+++ b/apps/todomvc/todomvc-web-components/src/utils/request-idle-callback.js
@@ -1,0 +1,21 @@
+export const requestIdleCallback = window.requestIdleCallback =
+    window.requestIdleCallback ||
+    function (cb) {
+        const start = Date.now();
+        const timeoutId = window.setTimeout(function () {
+            cb({
+                didTimeout: false,
+                timeRemaining: function () {
+                    return Math.max(0, 50 - (Date.now() - start));
+                }
+            });
+        }, 1)
+
+        return timeoutId;
+    }
+
+export const cancelIdleCallback = window.cancelIdleCallback =
+    window.cancelIdleCallback ||
+    function (id) {
+        window.clearTimeout(id);
+    }

--- a/apps/todomvc/todomvc-web-components/src/utils/request-idle-callback.js
+++ b/apps/todomvc/todomvc-web-components/src/utils/request-idle-callback.js
@@ -14,8 +14,4 @@ export const requestIdleCallback = window.requestIdleCallback =
         return timeoutId;
     }
 
-export const cancelIdleCallback = window.cancelIdleCallback =
-    window.cancelIdleCallback ||
-    function (id) {
-        window.clearTimeout(id);
-    }
+export const cancelIdleCallback = window.cancelIdleCallback || window.clearTimeout.bind(window);

--- a/apps/todomvc/todomvc-web-components/src/utils/script-loader.js
+++ b/apps/todomvc/todomvc-web-components/src/utils/script-loader.js
@@ -1,0 +1,37 @@
+import { requestIdleCallback } from "./request-idle-callback.js";
+
+function addScript(scriptEl, location) {
+    return new Promise((resolve) => {
+        if (location === 'head') {
+            document.head.appendChild(scriptEl);
+        } else {
+            document.body.appendChild(scriptEl);
+        }
+        return resolve({ success: true, type: "addScript"});
+    });
+}
+
+function initScript(scriptEl, url, strategy) {
+    return new Promise((resolve, reject) => {
+      scriptEl.onload = () => resolve({success: true, type: "loadScript"});
+      scriptEl.onerror = () => reject({success: false, type: "loadScript"});
+
+      switch(strategy) {
+        case "lazyOnLoad":
+            requestIdleCallback(() => scriptEl.setAttribute('src', url));
+            break;
+        default:
+            scriptEl.setAttribute('src', url);
+      }
+    });
+}
+
+export async function loadScript({ url, type, strategy, location, onError, onSuccess } = {}) {
+    const promisesToResolve = [];
+    const scriptEl = document.createElement('script');
+    scriptEl.type = type;
+    promisesToResolve.push(addScript(scriptEl, location));
+    promisesToResolve.push(initScript(scriptEl, url, strategy));
+
+    await Promise.all(promisesToResolve).then(() => onSuccess?.()).catch(() => onError?.());
+}

--- a/apps/todomvc/todomvc-web-components/src/utils/script-loader.js
+++ b/apps/todomvc/todomvc-web-components/src/utils/script-loader.js
@@ -41,7 +41,7 @@ function buildScript({scriptEl, code}) {
     });
 }
 
-export async function loadScript({ id, url = "", code = "", type = "", strategy = "default", location = "body", onError = () => {}, onSuccess = () => {} } = {}) {
+export async function loadScript({ id, url = "", code = "", type = "", strategy = "default", location = "body", onError, onSuccess } = {}) {
     // create a script element
     const { scriptEl } = await createScript({type});
 
@@ -50,10 +50,12 @@ export async function loadScript({ id, url = "", code = "", type = "", strategy 
 
     if (code !== "") {
         // add inline code to script element
-        await buildScript({scriptEl, code}).then(() => onSuccess?.()).catch(() => onError?.());
+        await buildScript({scriptEl, code});
+        onSuccess?.();
     } else {
         // load external url
-        await initScript({scriptEl, url, strategy}).then(() => onSuccess?.()).catch(() => onError?.());
+        const {success} = await initScript({scriptEl, url, strategy});
+        success ? onSuccess?.() : onError?.();
     }
 
     return ({ success: true, type: "loadScript", id});

--- a/apps/todomvc/todomvc-web-components/src/utils/script-loader.js
+++ b/apps/todomvc/todomvc-web-components/src/utils/script-loader.js
@@ -1,6 +1,6 @@
 import { requestIdleCallback } from "./request-idle-callback.js";
 
-function createScript(type) {
+function createScript({type}) {
     return new Promise((resolve) => {
         const scriptEl = document.createElement('script');
         if (type !== "") scriptEl.type = type;
@@ -8,7 +8,7 @@ function createScript(type) {
     });
 }
 
-function addScript(scriptEl, location) {
+function addScript({scriptEl, location}) {
     return new Promise((resolve) => {
         if (location === 'head') {
             document.head.appendChild(scriptEl);
@@ -19,7 +19,7 @@ function addScript(scriptEl, location) {
     });
 }
 
-function initScript(scriptEl, url, strategy) {
+function initScript({scriptEl, url, strategy}) {
     return new Promise((resolve, reject) => {
       scriptEl.onload = () => resolve({success: true, type: "initScript"});
       scriptEl.onerror = () => reject({success: false, type: "initScript"});
@@ -34,7 +34,7 @@ function initScript(scriptEl, url, strategy) {
     });
 }
 
-function buildScript(scriptEl, code) {
+function buildScript({scriptEl, code}) {
     return new Promise((resolve) => {
         scriptEl.textContent = code;
         return resolve({ success: true, type: "buildScript"});
@@ -43,17 +43,17 @@ function buildScript(scriptEl, code) {
 
 export async function loadScript({ id, url = "", code = "", type = "", strategy = "default", location = "body", onError = () => {}, onSuccess = () => {} } = {}) {
     // create a script element
-    const { scriptEl } = await createScript(type);
+    const { scriptEl } = await createScript({type});
 
     // add script to document
-    await addScript(scriptEl, location);
+    await addScript({scriptEl, location});
 
     if (code !== "") {
         // add inline code to script element
-        await buildScript(scriptEl, code).then(() => onSuccess?.()).catch(() => onError?.());
+        await buildScript({scriptEl, code}).then(() => onSuccess?.()).catch(() => onError?.());
     } else {
         // load external url
-        await initScript(scriptEl, url, strategy).then(() => onSuccess?.()).catch(() => onError?.());
+        await initScript({scriptEl, url, strategy}).then(() => onSuccess?.()).catch(() => onError?.());
     }
 
     return ({ success: true, type: "loadScript", id});

--- a/apps/todomvc/todomvc-web-components/src/utils/script-loader.js
+++ b/apps/todomvc/todomvc-web-components/src/utils/script-loader.js
@@ -39,8 +39,6 @@ export async function loadScript({
     type = "",
     strategy = "default",
     location = "body",
-    onSuccess,
-    onError,
 } = {}) {
     // create a script element
     const scriptEl = createScript({ type });
@@ -51,7 +49,6 @@ export async function loadScript({
     if (code !== "") {
         // add inline code to script element
         buildScript({ scriptEl, code });
-        onSuccess();
     } else {
         // load external url
         await initScript({ scriptEl, url, strategy });

--- a/apps/todomvc/todomvc-web-components/src/utils/script-loader.js
+++ b/apps/todomvc/todomvc-web-components/src/utils/script-loader.js
@@ -34,7 +34,6 @@ function initScript({ scriptEl, url, strategy }) {
 }
 
 export async function loadScript({
-    id,
     url = "",
     code = "",
     type = "",

--- a/apps/todomvc/todomvc-web-components/src/utils/script-loader.js
+++ b/apps/todomvc/todomvc-web-components/src/utils/script-loader.js
@@ -34,8 +34,25 @@ function initScript(scriptEl, url, strategy) {
     });
 }
 
-export async function loadScript({ url, type = "", strategy = "default", location, onError, onSuccess } = {}) {
-    const { scriptEl } = await createScript(type)
+function buildScript(scriptEl, code) {
+    return new Promise((resolve) => {
+        scriptEl.textContent = code;
+        return resolve({ success: true, type: "buildScript"});
+    });
+}
+
+export async function loadScript({ url, code = "", type = "", strategy = "default", location, onError, onSuccess } = {}) {
+    // create a script element
+    const { scriptEl } = await createScript(type);
+    
+    // add script to document
     await addScript(scriptEl, location);
-    await initScript(scriptEl, url, strategy).then(() => onSuccess?.()).catch(() => onError?.());
+
+    if (code !== "") {
+        // add inline code to script element
+        await buildScript(scriptEl, code).then(() => onSuccess?.()).catch(() => onError?.());
+    } else {
+        // load external url
+        await initScript(scriptEl, url, strategy).then(() => onSuccess?.()).catch(() => onError?.());
+    }
 }

--- a/apps/todomvc/todomvc-web-components/src/utils/script-loader.js
+++ b/apps/todomvc/todomvc-web-components/src/utils/script-loader.js
@@ -3,7 +3,7 @@ import { requestIdleCallback } from "./request-idle-callback.js";
 function createScript(type) {
     return new Promise((resolve) => {
         const scriptEl = document.createElement('script');
-        scriptEl.type = type;
+        if (type !== "") scriptEl.type = type;
         return resolve({ success: true, type: "createScript", scriptEl});
     });
 }
@@ -34,7 +34,7 @@ function initScript(scriptEl, url, strategy) {
     });
 }
 
-export async function loadScript({ url, type, strategy, location, onError, onSuccess } = {}) {
+export async function loadScript({ url, type = "", strategy = "default", location, onError, onSuccess } = {}) {
     const { scriptEl } = await createScript(type)
     await addScript(scriptEl, location);
     await initScript(scriptEl, url, strategy).then(() => onSuccess?.()).catch(() => onError?.());

--- a/apps/todomvc/todomvc-web-components/src/utils/script-loader.js
+++ b/apps/todomvc/todomvc-web-components/src/utils/script-loader.js
@@ -1,5 +1,13 @@
 import { requestIdleCallback } from "./request-idle-callback.js";
 
+function createScript(type) {
+    return new Promise((resolve) => {
+        const scriptEl = document.createElement('script');
+        scriptEl.type = type;
+        return resolve({ success: true, type: "createScript", scriptEl});
+    });
+}
+
 function addScript(scriptEl, location) {
     return new Promise((resolve) => {
         if (location === 'head') {
@@ -27,11 +35,7 @@ function initScript(scriptEl, url, strategy) {
 }
 
 export async function loadScript({ url, type, strategy, location, onError, onSuccess } = {}) {
-    const promisesToResolve = [];
-    const scriptEl = document.createElement('script');
-    scriptEl.type = type;
-    promisesToResolve.push(addScript(scriptEl, location));
-    promisesToResolve.push(initScript(scriptEl, url, strategy));
-
-    await Promise.all(promisesToResolve).then(() => onSuccess?.()).catch(() => onError?.());
+    const { scriptEl } = await createScript(type)
+    await addScript(scriptEl, location);
+    await initScript(scriptEl, url, strategy).then(() => onSuccess?.()).catch(() => onError?.());
 }

--- a/apps/todomvc/todomvc-web-components/src/utils/script-loader.js
+++ b/apps/todomvc/todomvc-web-components/src/utils/script-loader.js
@@ -21,8 +21,8 @@ function addScript(scriptEl, location) {
 
 function initScript(scriptEl, url, strategy) {
     return new Promise((resolve, reject) => {
-      scriptEl.onload = () => resolve({success: true, type: "loadScript"});
-      scriptEl.onerror = () => reject({success: false, type: "loadScript"});
+      scriptEl.onload = () => resolve({success: true, type: "initScript"});
+      scriptEl.onerror = () => reject({success: false, type: "initScript"});
 
       switch(strategy) {
         case "lazyOnLoad":
@@ -44,7 +44,7 @@ function buildScript(scriptEl, code) {
 export async function loadScript({ url, code = "", type = "", strategy = "default", location, onError, onSuccess } = {}) {
     // create a script element
     const { scriptEl } = await createScript(type);
-    
+
     // add script to document
     await addScript(scriptEl, location);
 
@@ -55,4 +55,6 @@ export async function loadScript({ url, code = "", type = "", strategy = "defaul
         // load external url
         await initScript(scriptEl, url, strategy).then(() => onSuccess?.()).catch(() => onError?.());
     }
+
+    return ({ success: true, type: "loadScript", id});
 }

--- a/apps/todomvc/todomvc-web-components/src/utils/script-loader.js
+++ b/apps/todomvc/todomvc-web-components/src/utils/script-loader.js
@@ -41,7 +41,7 @@ function buildScript(scriptEl, code) {
     });
 }
 
-export async function loadScript({ url, code = "", type = "", strategy = "default", location, onError, onSuccess } = {}) {
+export async function loadScript({ id, url = "", code = "", type = "", strategy = "default", location = "body", onError = () => {}, onSuccess = () => {} } = {}) {
     // create a script element
     const { scriptEl } = await createScript(type);
 

--- a/apps/todomvc/todomvc-web-components/src/utils/script-loader.js
+++ b/apps/todomvc/todomvc-web-components/src/utils/script-loader.js
@@ -54,11 +54,6 @@ export async function loadScript({
         onSuccess();
     } else {
         // load external url
-        try {
-            await initScript({ scriptEl, url, strategy });
-            onSuccess?.();
-        } catch (e) {
-            onError?.(e);
-        }
+        await initScript({ scriptEl, url, strategy });
     }
 }


### PR DESCRIPTION
This pr adds an example to load the 'benchmark-connector.min.js' file at a later time during `requestIdleCallback`, to ensure we're sending `app-ready` postMessage when the app is really ready.

Why is this important?
Benchmarks need to know when the workload is ready to run a test on it. Previously, a clunky function waited for certain elements to be ready instead, which doesn't guarantee that everything is initialized. 
This way (this pr), the workload has the power to decide when it is really really ready.

Basically it's a super simple script loader, to give a simplified version of what frameworks offer out of the box 😄 

What's important to look at:
- ignore the dist folder
- look at the script-loader.js file

@kara 